### PR TITLE
Remove emoji titles + sidebar display

### DIFF
--- a/src/lib/server/api/routes/groups/user.ts
+++ b/src/lib/server/api/routes/groups/user.ts
@@ -64,7 +64,6 @@ export const userGroup = new Elysia()
 					ethicsModalAcceptedAt: settings?.ethicsModalAcceptedAt ?? null,
 
 					activeModel: settings?.activeModel ?? DEFAULT_SETTINGS.activeModel,
-					hideEmojiOnSidebar: settings?.hideEmojiOnSidebar ?? DEFAULT_SETTINGS.hideEmojiOnSidebar,
 					disableStream: settings?.disableStream ?? DEFAULT_SETTINGS.disableStream,
 					directPaste: settings?.directPaste ?? DEFAULT_SETTINGS.directPaste,
 					shareConversationsWithModelAuthors:
@@ -83,7 +82,6 @@ export const userGroup = new Elysia()
 						shareConversationsWithModelAuthors: z
 							.boolean()
 							.default(DEFAULT_SETTINGS.shareConversationsWithModelAuthors),
-						hideEmojiOnSidebar: z.boolean().default(DEFAULT_SETTINGS.hideEmojiOnSidebar),
 						ethicsModalAccepted: z.boolean().optional(),
 						activeModel: z.string().default(DEFAULT_SETTINGS.activeModel),
 						customPrompts: z.record(z.string()).default({}),

--- a/src/lib/server/textGeneration/title.ts
+++ b/src/lib/server/textGeneration/title.ts
@@ -28,6 +28,7 @@ export async function* generateTitleForConversation(
 
 export async function generateTitle(prompt: string, modelId?: string) {
     if (config.LLM_SUMMARIZATION !== "true") {
+        // When summarization is disabled, use the first five words without adding emojis
         return prompt.split(/\s+/g).slice(0, 5).join(" ");
     }
 
@@ -37,7 +38,7 @@ export async function generateTitle(prompt: string, modelId?: string) {
         generateFromDefaultEndpoint({
             messages: [{ from: "user", content: prompt }],
             preprompt:
-                "You are a summarization AI. Summarize the user's request into a single short sentence of four words or less. Do not try to answer it, only summarize the user's query. Always start your answer with an emoji relevant to the summary",
+                "You are a summarization AI. Summarize the user's request into a single short sentence of four words or less. Do not try to answer it; only summarize the user's query.",
             generateSettings: {
                 max_new_tokens: 30,
             },
@@ -47,19 +48,12 @@ export async function generateTitle(prompt: string, modelId?: string) {
 		.then((summary) => {
 			const firstFive = prompt.split(/\s+/g).slice(0, 5).join(" ");
 			const trimmed = summary.trim();
-			// Fallback: if empty, use emoji + first five words
-			if (!trimmed) {
-				return "💬 " + firstFive;
-			}
-			// Ensure emoji prefix if missing
-			if (!/\p{Emoji}/u.test(trimmed.slice(0, 3))) {
-				return "💬 " + trimmed;
-			}
-			return trimmed;
+			// Fallback: if empty, return first five words only (no emoji)
+			return trimmed || firstFive;
 		})
 		.catch((e) => {
 			logger.error(e);
 			const firstFive = prompt.split(/\s+/g).slice(0, 5).join(" ");
-			return "💬 " + firstFive;
+			return firstFive;
 		});
 }

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -7,7 +7,6 @@ import { type Writable, writable, get } from "svelte/store";
 
 type SettingsStore = {
 	shareConversationsWithModelAuthors: boolean;
-	hideEmojiOnSidebar: boolean;
 	ethicsModalAccepted: boolean;
 	ethicsModalAcceptedAt: Date | null;
 	activeModel: string;

--- a/src/lib/types/Settings.ts
+++ b/src/lib/types/Settings.ts
@@ -14,7 +14,7 @@ export interface Settings extends Timestamps {
 	shareConversationsWithModelAuthors: boolean;
 	ethicsModalAcceptedAt: Date | null;
 	activeModel: string;
-	hideEmojiOnSidebar?: boolean;
+
 
 	// model name and system prompts
 	customPrompts?: Record<string, string>;
@@ -35,7 +35,6 @@ export type SettingsEditable = Omit<Settings, "ethicsModalAcceptedAt" | "created
 export const DEFAULT_SETTINGS = {
 	shareConversationsWithModelAuthors: true,
 	activeModel: defaultModel.id,
-	hideEmojiOnSidebar: false,
 	customPrompts: {},
 	multimodalOverrides: {},
 	disableStream: false,

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -23,11 +23,8 @@ export const load = async ({ depends, fetch, url }) => {
 
 	const { conversations: rawConversations, nConversations } = conversationsData;
 	const conversations = rawConversations.map((conv) => {
-		if (settings?.hideEmojiOnSidebar) {
-			conv.title = conv.title.replace(/\p{Emoji}/gu, "");
-		}
-
-		// Always strip <think> markers from titles for sidebar display
+		// Always strip emojis and <think> markers from titles for sidebar display
+		conv.title = conv.title.replace(/\p{Emoji}/gu, "");
 		conv.title = conv.title.replace(/<\/?think>/gi, "");
 
 		// remove invalid unicode and trim whitespaces

--- a/src/routes/settings/(nav)/+server.ts
+++ b/src/routes/settings/(nav)/+server.ts
@@ -12,7 +12,6 @@ export async function POST({ request, locals }) {
 			shareConversationsWithModelAuthors: z
 				.boolean()
 				.default(DEFAULT_SETTINGS.shareConversationsWithModelAuthors),
-			hideEmojiOnSidebar: z.boolean().default(DEFAULT_SETTINGS.hideEmojiOnSidebar),
 			ethicsModalAccepted: z.boolean().optional(),
 			activeModel: z.string().default(DEFAULT_SETTINGS.activeModel),
 			customPrompts: z.record(z.string()).default({}),

--- a/src/routes/settings/(nav)/application/+page.svelte
+++ b/src/routes/settings/(nav)/application/+page.svelte
@@ -93,17 +93,7 @@
 					</div>
 				{/if}
 
-				<div class="flex items-start justify-between py-3">
-					<div>
-						<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
-							Hide emoticons in topics
-						</div>
-						<p class="text-[12px] text-gray-500 dark:text-gray-400">
-							Hide emojis shown in the conversation list.
-						</p>
-					</div>
-					<Switch name="hideEmojiOnSidebar" bind:checked={$settings.hideEmojiOnSidebar} />
-				</div>
+
 
 				<div class="flex items-start justify-between py-3">
 					<div>


### PR DESCRIPTION
Summary\n- Stop adding emoji prefixes in generated titles (remove instruction + enforcement/fallback)\n- Always strip emojis from sidebar conversation titles\n- Remove the 'Hide emoticons in topics' setting (types, API, server route, UI)\n\nNotes\n- <think> tag sanitization remains intact.\n- Existing titles in DB may still contain emojis; they will no longer show in the left nav.